### PR TITLE
Add `calculator` console script entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "calculator-demo"
+version = "0.1.0"
+description = "A simple command-line calculator"
+requires-python = ">=3.11"
+
+[tool.setuptools.packages.find]
+include = ["src*"]
+
+[project.scripts]
+calculator = "src.main:main"


### PR DESCRIPTION
Adds a `pyproject.toml` with a console script entry point so you can run the calculator by simply typing `calculator` instead of `python3 -m src.main`.

## Changes
- Added `pyproject.toml` with build system config and `[project.scripts]` entry point
- Configured setuptools package discovery to include the `src` package

## Usage
After installing with `pip install -e .`, just run:
```bash
calculator
```