### PR TITLE
Add setup.py shim for older pip editable install compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Adds a minimal `setup.py` shim so that `pip install -e .` works on older pip versions (< 21.3) that don't support editable installs from `pyproject.toml` alone.

This fixes the error:
```
ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode
```