### PR TITLE
Lower requires-python to >=3.9 for broader compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "calculator-demo"
 version = "0.1.0"
 description = "A simple command-line calculator"
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 
 [tool.setuptools.packages.find]
 include = ["src*"]


### PR DESCRIPTION
Lowers `requires-python` from `>=3.11` to `>=3.9` so the package can be installed on machines running Python 3.9+.

This fixes:
```
ERROR: Package 'calculator-demo' requires a different Python: 3.9.6 not in '>=3.11'
```