### PR TITLE
Fix division to return decimal instead of integer

### DIFF
--- a/src/calculator.py
+++ b/src/calculator.py
@@ -21,7 +21,7 @@ def multiply(a, b):
 
 def divide(a, b):
     global result
-    result = a // b
+    result = a / b
     return result
 
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -15,8 +15,19 @@ def test_multiply():
 
 
 def test_divide_integer():
-    # This will fail because of integer division bug (uses // instead of /)
     assert divide(7, 2) == 3.5
+
+
+def test_divide_decimal_result():
+    assert divide(10, 3) == pytest.approx(3.333333, rel=1e-4)
+
+
+def test_divide_exact():
+    assert divide(10, 2) == 5.0
+
+
+def test_evaluate_division():
+    assert evaluate("7/2") == 3.5
 
 
 def test_divide_by_zero():


### PR DESCRIPTION
## What
The division operation in the calculator was truncating decimal results. For example, `7/2` returned `3` instead of `3.5`, and `10/3` returned `3` instead of `3.333...`.

## Why
The `divide()` function used Python's floor division operator (`//`) instead of true division (`/`), which discards the decimal portion of the result. This produced mathematically incorrect answers for any division that doesn't result in a whole number.

## How
- Changed `a // b` to `a / b` in the `divide()` function in `src/calculator.py`
- Added new tests for decimal division results (`10/3`, `10/2`) and an end-to-end `evaluate("7/2")` test
- Updated the existing `test_divide_integer` test comment to reflect the fix

Resolves #25